### PR TITLE
:rocket: 20190530-python-argparse-type-shape

### DIFF
--- a/python/argparse/Pipfile
+++ b/python/argparse/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+numpy = "*"
+
+[requires]
+python_version = "3.7"

--- a/python/argparse/custom_type.py
+++ b/python/argparse/custom_type.py
@@ -1,0 +1,23 @@
+import argparse
+import re
+
+import numpy as np
+
+
+def shape(string):
+    m = re.search(r'^\s*\(([\d\s,]+)\)\s*$', string)
+    if m is None:
+        raise ValueError
+    return tuple(map(int, m.group(1).split(',')))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input-shape', type=shape)
+    args = parser.parse_args()
+
+    print(np.ones(args.input_shape))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
argparseで独自のtypeを扱う。